### PR TITLE
Hopefully final tweaks to progress widget

### DIFF
--- a/tests/TestProgressWidget.cpp
+++ b/tests/TestProgressWidget.cpp
@@ -4,22 +4,22 @@
  * Kitware, Inc., 28 Corporate Drive, Clifton Park, NY 12065.
  */
 
-#include <QApplication>
-
 #include "../widgets/qtProgressWidget.h"
 
+#include <QApplication>
+
+//-----------------------------------------------------------------------------
 int main(int argc, char* argv[])
 {
-  QApplication app(argc, argv);
+    QApplication app{argc, argv};
 
-  qtProgressWidget widget;
-  widget.setNameVisible(true);
-  widget.addProgressBar("Task 1", "Description 1", 20);
-  widget.setValue("Task 2", 20);
-  widget.setRange("Task 2", 0, 40);
-  widget.setDescription("Task 3", "Description 3");
-  widget.addProgressBar("Task 4", "Description 4", 0, 0, 0);
+    qtProgressWidget widget;
+    widget.setLabelAlignment(Qt::AlignCenter);
 
-  widget.show();
-  return app.exec();
+    auto const task1 = widget.addTask("This is a sample task", 20);
+    auto const task2 = widget.addTask("This task is 'busy'");
+    widget.setProgressRange(task2, 0, 0);
+
+    widget.show();
+    return app.exec();
 }

--- a/widgets/qtProgressWidget.cpp
+++ b/widgets/qtProgressWidget.cpp
@@ -28,13 +28,13 @@ public:
 
     bool autoHide = true;
     bool labelVisible = true;
+    Qt::Alignment labelAlignment = Qt::AlignLeft | Qt::AlignVCenter;
 
     QHash<int, Task> tasks;
     QList<int> availableIds;
     int lastTaskId = -1;
 
     void updateVisibility(qtProgressWidget* self);
-    void updateLabelVisibility();
 
     int newTaskId();
 };
@@ -43,13 +43,6 @@ public:
 void qtProgressWidgetPrivate::updateVisibility(qtProgressWidget* self)
 {
   self->setVisible(!this->autoHide || !this->tasks.empty());
-}
-
-//-----------------------------------------------------------------------------
-void qtProgressWidgetPrivate::updateLabelVisibility()
-{
-  foreach (auto const& task, this->tasks)
-    task.label->setVisible(this->labelVisible);
 }
 
 //-----------------------------------------------------------------------------
@@ -109,7 +102,27 @@ void qtProgressWidget::setLabelVisible(bool visible)
     if (d->labelVisible != visible)
     {
         d->labelVisible = visible;
-        d->updateLabelVisibility();
+        foreach (auto const& task, d->tasks)
+            task.label->setVisible(visible);
+    }
+}
+
+//-----------------------------------------------------------------------------
+Qt::Alignment qtProgressWidget::labelAlignment() const
+{
+    QTE_D();
+    return d->labelAlignment;
+}
+
+//-----------------------------------------------------------------------------
+void qtProgressWidget::setLabelAlignment(Qt::Alignment alignment)
+{
+    QTE_D();
+    if (d->labelAlignment != alignment)
+    {
+        d->labelAlignment = alignment;
+        foreach (auto const& task, d->tasks)
+            task.label->setAlignment(alignment);
     }
 }
 
@@ -135,6 +148,7 @@ int qtProgressWidget::addTask(QString const& text, int value,
     this->layout()->addWidget(container);
 
     task.label->setVisible(d->labelVisible);
+    task.label->setAlignment(d->labelAlignment);
 
     task.progressBar->setRange(minimum, maximum);
     task.progressBar->setValue(value);

--- a/widgets/qtProgressWidget.cpp
+++ b/widgets/qtProgressWidget.cpp
@@ -22,14 +22,12 @@ public:
     struct Task
     {
         QWidget* container;
-        QLabel* nameLabel;
-        QLabel* descriptionLabel;
+        QLabel* label;
         QProgressBar* progressBar;
     };
 
     bool autoHide = true;
-    bool nameVisible = false;
-    bool descriptionVisible = true;
+    bool labelVisible = true;
 
     QHash<int, Task> tasks;
     QList<int> availableIds;
@@ -51,10 +49,7 @@ void qtProgressWidgetPrivate::updateVisibility(qtProgressWidget* self)
 void qtProgressWidgetPrivate::updateLabelVisibility()
 {
   foreach (auto const& task, this->tasks)
-  {
-    task.nameLabel->setVisible(this->nameVisible);
-    task.descriptionLabel->setVisible(this->descriptionVisible);
-  }
+    task.label->setVisible(this->labelVisible);
 }
 
 //-----------------------------------------------------------------------------
@@ -101,45 +96,26 @@ void qtProgressWidget::setAutoHide(bool hide)
 }
 
 //-----------------------------------------------------------------------------
-bool qtProgressWidget::nameVisible() const
+bool qtProgressWidget::labelVisible() const
 {
     QTE_D();
-    return d->nameVisible;
+    return d->labelVisible;
 }
 
 //-----------------------------------------------------------------------------
-void qtProgressWidget::setNameVisible(bool visible)
+void qtProgressWidget::setLabelVisible(bool visible)
 {
     QTE_D();
-    if (d->nameVisible != visible)
+    if (d->labelVisible != visible)
     {
-        d->nameVisible = visible;
+        d->labelVisible = visible;
         d->updateLabelVisibility();
     }
 }
 
 //-----------------------------------------------------------------------------
-bool qtProgressWidget::descriptionVisible() const
-{
-    QTE_D();
-    return d->descriptionVisible;
-}
-
-//-----------------------------------------------------------------------------
-void qtProgressWidget::setDescriptionVisible(bool visible)
-{
-    QTE_D();
-    if (d->descriptionVisible != visible)
-    {
-        d->descriptionVisible = visible;
-        d->updateLabelVisibility();
-    }
-}
-
-//-----------------------------------------------------------------------------
-int qtProgressWidget::addTask(
-    QString const& name, QString const& description,
-    int value, int minimum, int maximum)
+int qtProgressWidget::addTask(QString const& text, int value,
+                              int minimum, int maximum)
 {
     QTE_D();
 
@@ -150,19 +126,15 @@ int qtProgressWidget::addTask(
 
     qtProgressWidgetPrivate::Task task{
         container,
-        new QLabel{name, container},
-        new QLabel{description, container},
+        new QLabel{text, container},
         new QProgressBar{container},
     };
 
-    container->layout()->addWidget(task.nameLabel);
-    container->layout()->addWidget(task.descriptionLabel);
+    container->layout()->addWidget(task.label);
     container->layout()->addWidget(task.progressBar);
     this->layout()->addWidget(container);
 
-    task.nameLabel->setStyleSheet("font-weight: bold;");
-    task.nameLabel->setVisible(d->nameVisible);
-    task.descriptionLabel->setVisible(d->descriptionVisible);
+    task.label->setVisible(d->labelVisible);
 
     task.progressBar->setRange(minimum, maximum);
     task.progressBar->setValue(value);
@@ -198,39 +170,21 @@ QList<int> qtProgressWidget::tasks() const
 }
 
 //-----------------------------------------------------------------------------
-QString qtProgressWidget::taskName(int id) const
+QString qtProgressWidget::taskText(int id) const
 {
     QTE_D();
     if (auto const* const t = qtGet(d->tasks, id))
-        return t->nameLabel->text();
+        return t->label->text();
 
     return {};
 }
 
 //-----------------------------------------------------------------------------
-void qtProgressWidget::setTaskName(int id, QString const& name)
+void qtProgressWidget::setTaskText(int id, QString const& text)
 {
     QTE_D();
     if (auto const* const t = qtGet(d->tasks, id))
-        t->nameLabel->setText(name);
-}
-
-//-----------------------------------------------------------------------------
-QString qtProgressWidget::taskDescription(int id) const
-{
-    QTE_D();
-    if (auto const* const t = qtGet(d->tasks, id))
-        return t->descriptionLabel->text();
-
-    return {};
-}
-
-//-----------------------------------------------------------------------------
-void qtProgressWidget::setTaskDescription(int id, QString const& description)
-{
-    QTE_D();
-    if (auto const* const t = qtGet(d->tasks, id))
-        t->descriptionLabel->setText(description);
+        t->label->setText(text);
 }
 
 //-----------------------------------------------------------------------------

--- a/widgets/qtProgressWidget.h
+++ b/widgets/qtProgressWidget.h
@@ -25,59 +25,37 @@ class QTE_EXPORT qtProgressWidget : public QWidget
     /// By default, this property is \c true.
     Q_PROPERTY(bool autoHide READ autoHide WRITE setAutoHide)
 
-    /// This property controls whether the task name should be visible.
-    /// If true, the task name is displayed above the progress bar.
-    ///
-    /// By default, this property is \c false.
-    ///
-    /// \sa labelVisible
-    Q_PROPERTY(bool nameVisible READ nameVisible WRITE setNameVisible)
-
-    /// This property controls whether the description label should be visible.
-    /// If true, the label is displayed above the progress bar and below the
-    /// task name.
+    /// This property controls whether the task label should be visible. If
+    /// true, the task label is displayed above the progress bar.
     ///
     /// By default, this property is \c true.
-    ///
-    /// \sa nameVisible
-    Q_PROPERTY(bool descriptionVisible
-               READ descriptionVisible
-               WRITE setDescriptionVisible)
+    Q_PROPERTY(bool labelVisible READ labelVisible WRITE setLabelVisible)
 
 public:
     qtProgressWidget(QWidget* parent = nullptr);
     virtual ~qtProgressWidget();
 
     bool autoHide() const;
-    bool nameVisible() const;
-    bool descriptionVisible() const;
+    bool labelVisible() const;
 
 public slots:
     void setAutoHide(bool hide);
-    void setNameVisible(bool visible);
-    void setDescriptionVisible(bool visible);
+    void setLabelVisible(bool visible);
 
     /// Add a task to the widget.
     ///
     /// \return Identifier of the newly added task.
-    virtual int addTask(QString const& name,
-                        QString const& description = QString(""),
-                        int value = 0, int minimum = 0, int maximum = 100);
+    virtual int addTask(QString const& text = QString(""), int value = 0,
+                        int minimum = 0, int maximum = 100);
 
     // Get list of all tasks.
     QList<int> tasks() const;
 
-    // Get the name of the specified task.
-    QString taskName(int id) const;
+    // Get the text of the specified task.
+    QString taskText(int id) const;
 
-    // Set the name of a particular task.
-    void setTaskName(int id, QString const& name);
-
-    /// Get the description of the specified task.
-    QString taskDescription(int id) const;
-
-    /// Set the description of a particular task.
-    void setTaskDescription(int id, QString const& description);
+    // Set the text of a particular task.
+    void setTaskText(int id, QString const& text);
 
     /// Set the value range for a particular task's progress bar.
     ///

--- a/widgets/qtProgressWidget.h
+++ b/widgets/qtProgressWidget.h
@@ -31,22 +31,17 @@ class QTE_EXPORT qtProgressWidget : public QWidget
     /// By default, this property is \c true.
     Q_PROPERTY(bool labelVisible READ labelVisible WRITE setLabelVisible)
 
+    /// This property controls the text alignment of the task labels.
+    Q_PROPERTY(Qt::Alignment labelAlignment READ labelAlignment
+                                            WRITE setLabelAlignment)
+
 public:
     qtProgressWidget(QWidget* parent = nullptr);
     virtual ~qtProgressWidget();
 
     bool autoHide() const;
     bool labelVisible() const;
-
-public slots:
-    void setAutoHide(bool hide);
-    void setLabelVisible(bool visible);
-
-    /// Add a task to the widget.
-    ///
-    /// \return Identifier of the newly added task.
-    virtual int addTask(QString const& text = QString(""), int value = 0,
-                        int minimum = 0, int maximum = 100);
+    Qt::Alignment labelAlignment() const;
 
     // Get list of all tasks.
     QList<int> tasks() const;
@@ -54,8 +49,21 @@ public slots:
     // Get the text of the specified task.
     QString taskText(int id) const;
 
+public slots:
+    void setAutoHide(bool hide);
+    void setLabelVisible(bool visible);
+    void setLabelAlignment(Qt::Alignment);
+
+    /// Add a task to the widget.
+    ///
+    /// \return Identifier of the newly added task.
+    virtual int addTask(QString const& text = QString(""), int value = 0,
+                        int minimum = 0, int maximum = 100);
+
     // Set the text of a particular task.
     void setTaskText(int id, QString const& text);
+
+    /// Set the text alignment of the task labels.
 
     /// Set the value range for a particular task's progress bar.
     ///


### PR DESCRIPTION
- Use only one label. Based on what I saw from @mleotta, we don't need both at this time (and anyway can achieve similar results using rich text). This simplifies the API while leaving it open to additions in the future, which is preferable to removing unneeded features later.
- Allow setting label alignment (as it appears we would like centered text?).
- Fix some methods that should not be slots.